### PR TITLE
chore: Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,21 +11,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '25'
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/caches
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-${{ runner.os }}-
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/wrapper
           key: gradle-wrapper-${{ runner.os }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
@@ -36,7 +36,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --full-stacktrace
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Artifacts
           path: build/libs/*-release.jar


### PR DESCRIPTION
Upgrading is required soon due to node.js v20 actions being deprecated...
<img width="1026" height="273" alt="image" src="https://github.com/user-attachments/assets/c32223e2-1167-40a7-9d2b-8bb38a887433" />
