### PR TITLE
chore: provide dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+registries:
+  labymod-maven:
+    type: maven-repository
+    url: https://dist.labymod.net/api/v1/maven/release/
+
+  neoforged-maven:
+    type: maven-repository
+    url: https://maven.neoforged.net/releases/
+
+  fabricmc-maven:
+    type: maven-repository
+    url: https://maven.fabricmc.net/
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: gradle
+    directory: /
+    registries: '*'
+    schedule:
+      interval: weekly


### PR DESCRIPTION
A simple Dependabot configuration to check for and update Gradle dependencies and Github actions every week.